### PR TITLE
BASIC認証の追加

### DIFF
--- a/api/basic_auth.py
+++ b/api/basic_auth.py
@@ -1,0 +1,38 @@
+import secrets
+import os
+
+from fastapi import HTTPException, status, Request, Depends
+from fastapi.staticfiles import StaticFiles
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+security = HTTPBasic()
+
+
+def auth_basic(credentials: HTTPBasicCredentials):
+    correct_username = secrets.compare_digest(
+        credentials.username, os.environ.get("BASIC_USER"))
+    correct_password = secrets.compare_digest(
+        credentials.password, os.environ.get("BASIC_PASSWORD"))
+    if not (correct_username and correct_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+
+
+def verify_from_api(credentials: HTTPBasicCredentials = Depends(security)):
+    auth_basic(credentials)
+
+
+class AuthStaticFiles(StaticFiles):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    async def __call__(self, scope, receive, send) -> None:
+        assert scope["type"] == "http"
+
+        request = Request(scope, receive)
+        credentials = await security(request)
+        auth_basic(credentials)
+        await super().__call__(scope, receive, send)

--- a/api/basic_auth.py
+++ b/api/basic_auth.py
@@ -16,7 +16,7 @@ def auth_basic(credentials: HTTPBasicCredentials):
     if not (correct_username and correct_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect email or password",
+            detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Basic"},
         )
 

--- a/api/basic_auth.py
+++ b/api/basic_auth.py
@@ -9,14 +9,12 @@ security = HTTPBasic()
 
 
 def auth_basic(credentials: HTTPBasicCredentials):
-    correct_username = secrets.compare_digest(
-        credentials.username, os.environ.get("BASIC_USER"))
-    correct_password = secrets.compare_digest(
-        credentials.password, os.environ.get("BASIC_PASSWORD"))
+    correct_username = secrets.compare_digest(credentials.username, os.environ.get("BASIC_USER"))
+    correct_password = secrets.compare_digest(credentials.password, os.environ.get("BASIC_PASSWORD"))
     if not (correct_username and correct_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect email or password",
+            detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Basic"},
         )
 
@@ -30,7 +28,8 @@ class AuthStaticFiles(StaticFiles):
         super().__init__(*args, **kwargs)
 
     async def __call__(self, scope, receive, send) -> None:
-        assert scope["type"] == "http"
+        if scope["type"] != "http":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid scope type")
 
         request = Request(scope, receive)
         credentials = await security(request)

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from starlette.middleware.cors import CORSMiddleware
 from mangum import Mangum
 from logging import getLogger, StreamHandler, DEBUG
@@ -13,6 +13,7 @@ from routers.review import router as reviewRouter
 from routers.advent_calendar import router as adventCalendarRouter
 from routers.advent_calendar_article import router as adventCalendarArticleRouter
 from routers.signup import router as signupRouter
+from basic_auth import verify_from_api
 
 
 logger = getLogger(__name__)
@@ -52,8 +53,7 @@ class LoggingContextRoute(APIRoute):
 
         return custom_route_handler
 
-
-_app = FastAPI()
+_app = FastAPI(dependencies=[Depends(verify_from_api)])
 _app.router.route_class = LoggingContextRoute
 _app.include_router(signupRouter)
 _app.include_router(loginRouter)


### PR DESCRIPTION
APIを無制限に利用できないように、認証を設定する

参考：[FastAPIでBasic認証 #Python - Qiita](https://qiita.com/taumu/items/e448259a132bdbacf31c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented HTTP Basic authentication for enhanced security.
  - Added a custom class to handle authenticated access to static files.

- **Refactor**
  - Integrated new authentication dependencies into the FastAPI application setup.

- **Documentation**
  - Updated import statements to reflect new authentication features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->